### PR TITLE
modify short open tag <? to <?php

### DIFF
--- a/cookieviz/settings.inc
+++ b/cookieviz/settings.inc
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /**
  * This file holds the database settings used by CookieViz.


### PR DESCRIPTION
The short open tags is deprecated in php 5.4
